### PR TITLE
Vm 895

### DIFF
--- a/src/VirtoCommerce.MarketplaceCommissionsModule.Web/Scripts/blades/fee-dynamic-details.js
+++ b/src/VirtoCommerce.MarketplaceCommissionsModule.Web/Scripts/blades/fee-dynamic-details.js
@@ -203,17 +203,30 @@ angular.module('virtoCommerce.marketplaceCommissionsModule')
             };
 
             function fillIncludingCategoriesBlock(filteredCategories) {
-                if (filteredCategories) {
-                    let commonConditionBlock = blade.currentEntity.expressionTree.children.filter(x => x.id === 'BlockCommissionCondition').find(o => true);
-                    let categoryIsConditionBlock = commonConditionBlock && commonConditionBlock.children
-                        ? commonConditionBlock.children.filter(x => x.id === 'VcmpConditionCategoryIs').find(o => true)
-                        : undefined;
-                    if (categoryIsConditionBlock && filteredCategories.length > 0) {
-                        categoryIsConditionBlock.categoryId = filteredCategories[0].id;
-                        categoryIsConditionBlock.categoryName = filteredCategories[0].name;
-                    }
+                if (!filteredCategories) {
+                    return;
                 }
-            };
+
+                const blockCondition = blade.currentEntity.expressionTree.children
+                    .find(x => x.id === 'BlockCommissionCondition');
+
+                if (blockCondition && Array.isArray(blockCondition.children)) {
+                    blockCondition.children
+                        .filter(x =>
+                            x.id === 'VcmpConditionCategoryIs' &&
+                            Array.isArray(x.includingCategories) &&
+                            x.includingCategories.length === 1
+                        )
+                        .forEach(categoryIsCond => {
+                            const categoryId = categoryIsCond.includingCategories[0];
+                            const category = filteredCategories.find(f => f.id === categoryId);
+                            if (category) {
+                                categoryIsCond.categoryId = category.id;
+                                categoryIsCond.categoryName = category.name;
+                            }
+                        });
+                }
+            }
 
             function fillExcludingCategoriesBlock(filteredCategories) {
                 if (filteredCategories) {
@@ -253,15 +266,24 @@ angular.module('virtoCommerce.marketplaceCommissionsModule')
             };
 
             function fillProductsBlock(filteredProducts) {
-                if (filteredProducts) {
-                    let commonConditionBlock = blade.currentEntity.expressionTree.children.filter(x => x.id === 'BlockCommissionCondition').find(o => true);
-                    let productIsConditionBlock = commonConditionBlock && commonConditionBlock.children
-                        ? commonConditionBlock.children.filter(x => x.id === 'VcmpConditionProductIs').find(o => true)
-                        : undefined;
-                    if (productIsConditionBlock) {
-                        productIsConditionBlock.productNames = filteredProducts.map(x => x.name);
-                        productIsConditionBlock.productCodes = filteredProducts.map(x => x.code);
-                    }
+                if (!filteredProducts) {
+                    return;
+                } 
+
+                const blockCondition = blade.currentEntity.expressionTree.children
+                    .find(x => x.id === 'BlockCommissionCondition');
+
+                if (blockCondition && Array.isArray(blockCondition.children)) {
+                    blockCondition.children
+                        .filter(x => x.id === 'VcmpConditionProductIs' && Array.isArray(x.includingProducts) && x.includingProducts.length === 1)
+                        .forEach(productIsCond => {
+                            const productId = productIsCond.includingProducts[0];
+                            const product = filteredProducts.find(f => f.id === productId);
+                            if (product) {
+                                productIsCond.productNames = [product.name];
+                                productIsCond.productCodes = [product.code];
+                            }
+                        });
                 }
             };
 

--- a/src/VirtoCommerce.MarketplaceCommissionsModule.Web/Scripts/blades/fee-dynamic-details.js
+++ b/src/VirtoCommerce.MarketplaceCommissionsModule.Web/Scripts/blades/fee-dynamic-details.js
@@ -117,17 +117,12 @@ angular.module('virtoCommerce.marketplaceCommissionsModule')
             };
 
             $scope.validatePriorityAsync = function (value) {
-                if (value > 0) {
-                    if (Number.isInteger(value)) {
-                        $scope.errorData = null;
-                        return $q.resolve();
-                    }
-                    else {
-                        $scope.errorData = 'PriorityNotInteger';
-                        return $q.reject();
-                    }
-                } else {
-                    $scope.errorData = 'PriorityNotPositive';
+                if (Number.isInteger(value)) {
+                    $scope.errorData = null;
+                    return $q.resolve();
+                }
+                else {
+                    $scope.errorData = 'PriorityNotInteger';
                     return $q.reject();
                 }
             };


### PR DESCRIPTION
**Fix: Populate product and category names/codes for multiple condition blocks**

Previously, the logic for enriching BlockCommissionCondition children (fillProductsBlock and fillIncludingCategoriesBlock functions) only handled the first matching child and did not properly support scenarios where there are multiple child blocks for products or categories. As a result, only a single condition block would be enriched, leaving other relevant blocks unmodified.
Jira-link:
https://virtocommerce.atlassian.net/browse/VM-895