### PR TITLE
feat: migrate MF remote to backoffice modularity contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,4 +336,6 @@ ASALocalRun/
 *.zip
 .nuke
 dist/
+# MF plugin remote build output (platform manifest discovery folder)
+src/VirtoCommerce.MarketplaceCommissionsModule.Web/plugins/
 **/Properties/launchSettings.json

--- a/src/VirtoCommerce.MarketplaceCommissionsModule.Web/commissions-app/package.json
+++ b/src/VirtoCommerce.MarketplaceCommissionsModule.Web/commissions-app/package.json
@@ -27,8 +27,8 @@
     "@types/node": "^20.10.5",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
-    "@vc-shell/api-client-generator": "^2.0.2",
-    "@vc-shell/ts-config": "v2.0.0-alpha.28",
+    "@vc-shell/api-client-generator": "^2.0.5",
+    "@vc-shell/ts-config": "^2.0.5",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/eslint-config-prettier": "^9.0.0",
     "@vue/eslint-config-typescript": "^12.0.0",
@@ -56,9 +56,9 @@
     "vue-tsc": "^2.2.10"
   },
   "dependencies": {
-    "@vc-shell/config-generator": "^2.0.2",
-    "@vc-shell/framework": "^2.0.2",
-    "@vc-shell/mf-module": "^2.0.2",
+    "@vc-shell/config-generator": "^2.0.5",
+    "@vc-shell/framework": "^2.0.5",
+    "@vc-shell/mf-module": "^2.0.5",
     "@vcmp-marketplace-commissions/api": "1.0.0",
     "@vueuse/core": "^10.7.1",
     "@vueuse/integrations": "^10.7.1",

--- a/src/VirtoCommerce.MarketplaceCommissionsModule.Web/commissions-app/src/modules/vite.config.with-api.mts
+++ b/src/VirtoCommerce.MarketplaceCommissionsModule.Web/commissions-app/src/modules/vite.config.with-api.mts
@@ -1,8 +1,15 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import { getDynamicModuleConfiguration } from "@vc-shell/mf-module";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// vite.config sits at commissions-app/src/modules/, .NET module root is three levels up.
+const moduleRoot = path.resolve(__dirname, "../../..");
 
 export default getDynamicModuleConfiguration({
   entry: "./src/modules/index.ts",
-  compatibility: {
-    framework: "^2.0.0",
-  },
+  appId: "vendor-portal",
+  moduleRoot,
+  remoteName: "VirtoCommerce.MarketplaceCommissions",
 });

--- a/src/VirtoCommerce.MarketplaceCommissionsModule.Web/commissions-app/yarn.lock
+++ b/src/VirtoCommerce.MarketplaceCommissionsModule.Web/commissions-app/yarn.lock
@@ -3356,9 +3356,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vc-shell/api-client-generator@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@vc-shell/api-client-generator@npm:2.0.2"
+"@vc-shell/api-client-generator@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@vc-shell/api-client-generator@npm:2.0.5"
   dependencies:
     chalk: "npm:^2.4.2"
     cross-spawn: "npm:^7.0.3"
@@ -3368,13 +3368,13 @@ __metadata:
     vite-plugin-dts: "npm:^3.6.4"
   bin:
     api-client-generator: ./dist/api-client-generator.js
-  checksum: 1c68a647d976f43163f3f88da99c2adfaaa881aadae452f03ca3386b6409da41b55f7fc7b48fa5d918cfc47d1cc7188be662d20bb16a9c17015c73ad291e8634
+  checksum: bbc43aaf4284fbd618b6cda1ade4d557a283777b794fdb1beeeb38ad8d3e37f895673aa920c205f39fb8fda04b8130768a2c95eb78763f6b73eaafd62b749680
   languageName: node
   linkType: hard
 
-"@vc-shell/config-generator@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@vc-shell/config-generator@npm:2.0.2"
+"@vc-shell/config-generator@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@vc-shell/config-generator@npm:2.0.5"
   dependencies:
     "@babel/parser": "npm:^7.27.0"
     "@vitejs/plugin-vue": "npm:^5.2.3"
@@ -3384,13 +3384,13 @@ __metadata:
     vite-plugin-circular-dependency: "npm:^0.5.0"
     vite-plugin-mkcert: "npm:^1.17.1"
     vue: "npm:^3.5.30"
-  checksum: c7838b632288e8eb279676a89fb33cd1ae9f617d2b2c8cf78fe88430b860c9d41650d055830040508b79d02773c6251048de67bc125b60c3e0869a2f95612d44
+  checksum: 5df0c491ef8e1e603daf0bc2ccf25a9210f3c99387206e0e0022798363df17ad085e68aab84e17f52c44c44927d4e5fd403a48642cfa673a16f40144b53e1276
   languageName: node
   linkType: hard
 
-"@vc-shell/framework@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@vc-shell/framework@npm:2.0.2"
+"@vc-shell/framework@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@vc-shell/framework@npm:2.0.5"
   dependencies:
     "@floating-ui/dom": "npm:^1.7.4"
     "@floating-ui/vue": "npm:^1.0.6"
@@ -3454,35 +3454,35 @@ __metadata:
       optional: false
   bin:
     vc-check-locales: ./dist/scripts/check-locales.cjs
-  checksum: f4f05d0f701b8bc7e86e8dec3f05bc4f85369bd5d13b657bbf5b038e17acdc43ed920f888174c94fb4b687b2cb22450a76fc1e60aebb09c1c2e4d07edfab6540
+  checksum: 3749a5dedcdee3b898f7b95a00ba0a167bdb8099137fce32b3a2f2b192e72db4d2eb6c55495b6a41b2b344289099b7b2bf635d7c7929ca2a8c32e12dd1fd3886
   languageName: node
   linkType: hard
 
-"@vc-shell/mf-config@npm:2.0.2":
-  version: 2.0.2
-  resolution: "@vc-shell/mf-config@npm:2.0.2"
-  checksum: acfe8bbda4acb3b381e06748e037ee16359f80b5fcb38c06acd368df31a71280b595eec862a0f45d29c34ec64d0e5a566849033fac99b5892e16e536c2f2085c
+"@vc-shell/mf-config@npm:2.0.5":
+  version: 2.0.5
+  resolution: "@vc-shell/mf-config@npm:2.0.5"
+  checksum: c63344f2dc19cd115744696c768349c97b4f3192534afacb32dbec65aeb48d1c4676f1d81c24a7adca129b772281d3f5260d12e0682f35e79f8c7c4f374639df
   languageName: node
   linkType: hard
 
-"@vc-shell/mf-module@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@vc-shell/mf-module@npm:2.0.2"
+"@vc-shell/mf-module@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@vc-shell/mf-module@npm:2.0.5"
   dependencies:
     "@module-federation/vite": "npm:^1.12.2"
-    "@vc-shell/mf-config": "npm:2.0.2"
+    "@vc-shell/mf-config": "npm:2.0.5"
   peerDependencies:
-    "@vc-shell/config-generator": ^2.0.2
+    "@vc-shell/config-generator": ^2.0.5
     "@vitejs/plugin-vue": ^5.0.0
     vite: ^5.0.0 || ^6.0.0
-  checksum: 137e6cf36df8cc28cfd4862c47cb697f22a115efb02ca41b971a77c3cee1cf5a775945aea9b46bc5fe4de2bda286a20aa3468dec615b5644a50d98ceea0251b7
+  checksum: bb5307f60b16f862e1b79bcca7c9ce026d8b59ca2b469e5476a50aad888f41940270bf08836f00461716e91d40344464c2851641341f874e4a6c44911857108d
   languageName: node
   linkType: hard
 
-"@vc-shell/ts-config@npm:v2.0.0-alpha.28":
-  version: 2.0.0-alpha.28
-  resolution: "@vc-shell/ts-config@npm:2.0.0-alpha.28"
-  checksum: 3b10a71ab0c1532df796e42cd0c9d850082ee3eec8a1a6e49aeb7935b805755eb5c214a333752b46bddc78b45a23e3f8d7c6f89ff4814cba53ed833b09b351a0
+"@vc-shell/ts-config@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@vc-shell/ts-config@npm:2.0.5"
+  checksum: cf06e8bee2c9afbe6288629eedc60f10f914692fc3e57e0fde977960362cbb431491b4dc57844da89598eb650f594f5070feb5b8e3702cfb43c05093bac8071e
   languageName: node
   linkType: hard
 
@@ -4785,11 +4785,11 @@ __metadata:
     "@types/node": "npm:^20.10.5"
     "@typescript-eslint/eslint-plugin": "npm:^6.16.0"
     "@typescript-eslint/parser": "npm:^6.16.0"
-    "@vc-shell/api-client-generator": "npm:^2.0.2"
-    "@vc-shell/config-generator": "npm:^2.0.2"
-    "@vc-shell/framework": "npm:^2.0.2"
-    "@vc-shell/mf-module": "npm:^2.0.2"
-    "@vc-shell/ts-config": "npm:v2.0.0-alpha.28"
+    "@vc-shell/api-client-generator": "npm:^2.0.5"
+    "@vc-shell/config-generator": "npm:^2.0.5"
+    "@vc-shell/framework": "npm:^2.0.5"
+    "@vc-shell/mf-module": "npm:^2.0.5"
+    "@vc-shell/ts-config": "npm:^2.0.5"
     "@vcmp-marketplace-commissions/api": "npm:1.0.0"
     "@vitejs/plugin-vue": "npm:^5.2.3"
     "@vue/eslint-config-prettier": "npm:^9.0.0"


### PR DESCRIPTION
## Summary

Migrates this module's federation remote to the platform's new Backoffice Modularity contract.

- `vite.config.with-api.mts`: declare `appId: "vendor-portal"`, `moduleRoot`, `remoteName: "VirtoCommerce.MarketplaceCommissions"`
- Drop client-side `compatibility` metadata — the platform validates module dependencies via `module.manifest` at install time
- Bump `@vc-shell/*` to `^2.0.5`
- Build output now lands at `<moduleRoot>/plugins/vendor-portal/remoteEntry.js` — where the platform's `GET /api/apps/vendor-portal/manifest` endpoint discovers plugin remotes
- Add `plugins/` to `.gitignore`

## Compatibility

Depends on `@vc-shell/framework@^2.0.5` and the matching `@vc-shell/mf-module`. The corresponding @vc-shell release must be published before this PR's CI install will succeed.

## Test plan

- [x] CI build passes against published `@vc-shell/*@^2.0.5`
- [x] Module installs into a platform running the Backoffice Modularity Framework
- [x] `/api/apps/vendor-portal/manifest` returns this plugin entry
- [x] Plugin's UI loads in vendor-portal end-to-end