### PR TITLE
VCST-5373: Use NuGet trusted publishing

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -201,7 +201,7 @@ jobs:
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/dev') }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.13
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.42
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -33,12 +33,17 @@ jobs:
         (github.event.pull_request.head.repo.full_name == github.repository ||
         github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
     runs-on: ubuntu-24.04
+    # Default GITHUB_TOKEN creates the release + updates the PR; rest uses the REPO_TOKEN PAT.
+    # id-token: write lets NuGet/login mint a short-lived OIDC key (Trusted Publishing).
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     env:
       CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
       CLIENT_ID: ${{secrets.CLIENT_ID}}
       CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
       GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-      NUGET_KEY: ${{ secrets.NUGET_KEY }}
       BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
       VERSION_SUFFIX: ''
       BUILD_STATE: 'failed'
@@ -104,9 +109,21 @@ jobs:
       - name: Packaging
         run: vc-build Compress -skip Clean+Restore+Compile+Test
 
+      # Trusted Publishing: swap the GitHub OIDC token for a ~1h nuget.org key, minted right before push.
+      - name: NuGet login (OIDC -> temp API key)
+        if: ${{ (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master') && github.event_name != 'workflow_dispatch' }}
+        id: nuget_login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          # nuget.org user that created the trust policy (shared service account). Hardcoded because
+          # private repos can't read org-level Actions variables in the current plan.
+          user: virto
+
       - name: Publish Nuget
         if: ${{ (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master') && github.event_name != 'workflow_dispatch' }}
         uses: VirtoCommerce/vc-github-actions/publish-nuget@master
+        env:
+          NUGET_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
 
       - name: Publish to Blob
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.13
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.42
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
Mint a short-lived nuget.org key via OIDC (NuGet/login) in the ci job and push with it, replacing the long-lived NUGET_KEY secret. Trusted user hardcoded 'virto'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches package publishing credentials and reusable deploy/release workflow versions; trusted publishing reduces secret exposure but misconfiguration could block NuGet pushes.
> 
> **Overview**
> **Module CI** no longer uses the long-lived `NUGET_KEY` secret for NuGet pushes. On `dev`/`master` (excluding `workflow_dispatch`), it runs **NuGet/login** to exchange a GitHub OIDC token for a short-lived API key and passes that key into the existing **Publish Nuget** step.
> 
> The **ci** job adds **`id-token: write`** (plus `contents` / `pull-requests` write) so OIDC minting works, and documents that the default `GITHUB_TOKEN` vs `REPO_TOKEN` split is unchanged. The trusted nuget.org user is set to **`virto`** in the login step (hardcoded per org/repo variable limits).
> 
> **deploy-cloud** and the standalone **release** workflow are bumped from **v3.800.13** to **v3.800.42** on the shared VirtoCommerce `.github` reusable workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c98a6012f80c9aa3669971ba6739f8be80a4b339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5373